### PR TITLE
Update matlab.vim

### DIFF
--- a/syntax/matlab.vim
+++ b/syntax/matlab.vim
@@ -16,7 +16,7 @@ endif
 
 syn keyword matlabStatement		return function
 syn keyword matlabConditional		switch case else elseif end if otherwise break continue
-syn keyword matlabRepeat		do for while
+syn keyword matlabRepeat		for while
 syn keyword matlabStorageClass		classdef methods properties events persistent global
 syn keyword matlabExceptions		try catch rethrow throw
 


### PR DESCRIPTION
This PR removes `do` from the syntax highlighting for MATLAB because I don't think `do` is a reserved keyword.